### PR TITLE
Delete node using node_id rather than by type & value

### DIFF
--- a/cybexapi/api.py
+++ b/cybexapi/api.py
@@ -143,12 +143,12 @@ class insert(APIView):
 class delete(APIView):
     permission_classes = (IsAuthenticated, )
 
-    def get(self, request, format=None, node_type=None, data=None):
+    def get(self, request, format=None, node_id=None):
         current_user = request.user
         graph = connect2graph(current_user.graphdb.dbuser, current_user.graphdb.dbpass,
                               current_user.graphdb.dbip, current_user.graphdb.dbport)
         
-        status = delete_node(node_type, data, graph)
+        status = delete_node(node_id, graph)
 
         if status == 1:
             return Response({"Status": "Success"})

--- a/cybexapi/delete_node.py
+++ b/cybexapi/delete_node.py
@@ -1,18 +1,13 @@
 import json
 import os
 
-def delete_node(node_type, data, graph):
-    # print(node_type)
-    # print(data)
-    
-    # The line below will do the same thing as the match function in graph.evaulate
-    # ip_node = graph.nodes.match(node_type, data=node).first()
-
-    node = f"\"{data}\""
+def delete_node(node_id, graph):
+    # print(node_id)
 
     # Need to add a check to see if the test doesn't return true
-    del_node = graph.evaluate(f"MATCH (n:{node_type}) where n.data = {node} RETURN n")
-    # print(test.identity)
+    del_node = graph.evaluate(f"MATCH (n) \
+                WHERE id(n) = {node_id} \
+                RETURN n")
 
     graph.delete(del_node)
     print("Deleted node")

--- a/cybexapi/urls.py
+++ b/cybexapi/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path('api/v1/neo4j/export', exportNeoDB.as_view()),
     path('api/v1/neo4j/insert/<x>/<y>/', insert.as_view()),
     path('api/v1/enrich/<x>/<y>/', enrichNode.as_view()),
-    path('api/v1/delete/<node_type>/<data>/', delete.as_view()),
+    path('api/v1/delete/<node_id>/', delete.as_view()),
     path('api/v1/enrich/<x>/', enrichNodePost.as_view()),
     path('api/v1/enrichURL', enrichURL.as_view()),
     path('api/v1/macroCybex', macroCybex.as_view()),

--- a/cybexweb/graph/src/components/radialMenu/withNodeType.jsx
+++ b/cybexweb/graph/src/components/radialMenu/withNodeType.jsx
@@ -78,11 +78,11 @@ function withNodeType(RadialMenuComponent, nodeType, setNeo4jData, config) {
     }
   }
 
-  function deleteNode(type,value)
+  function deleteNode(id)
   {
     axios
         // replace below with actual node deletion api call
-        .get(`/api/v1/delete/${type}/${value}`)
+        .get(`/api/v1/delete/${id}`)
         .then(({ data }) => {
           if (data['insert status'] !== 0) {
             axios
@@ -162,7 +162,7 @@ function withNodeType(RadialMenuComponent, nodeType, setNeo4jData, config) {
             bottom: "10px",
             zIndex: 100000
           }} 
-          onClick={() => deleteNode(nodeType.properties.type, nodeType.properties.data)}
+          onClick={() => deleteNode(nodeType.id)}
         >
           <p>Delete {nodeType.properties.type}: {nodeType.properties.data}</p>
         </div>


### PR DESCRIPTION
Updated the delete node functionality to use the unique identifier of a node. 