### PR TITLE
Rough solution for cybex api rate limit

### DIFF
--- a/cybexapi/api.py
+++ b/cybexapi/api.py
@@ -223,6 +223,8 @@ class macroCybex(APIView):
                 thread_list.append(thread)
             for thread in thread_list:
                 thread.start()
+                # thread.start()
+                # time.sleep(2)
             for thread in thread_list:
                 thread.join()
             ## End of threaded version


### PR DESCRIPTION
To reduce failures cybexRelated request now retries timed-out requests

Requests retry at random intervals to reduce api server load

A more permanent solution is needed